### PR TITLE
Added depth environment variable to SCA scan

### DIFF
--- a/.github/workflows/synopsis-scan-sca.yml
+++ b/.github/workflows/synopsis-scan-sca.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: string
         default: RAPID
+      SCAN_DEPTH:
+        required: false
+        type: string
+        default: "0"
     secrets:
       BLACKDUCK_API_TOKEN:
         required: true
@@ -39,6 +43,7 @@ jobs:
       uses: synopsys-sig/detect-action@v0.3.2
       env:
         DETECT_PROJECT_GROUP_NAME: ${{ inputs.APPLICATION_NAME }}
+        DETECT_DETECTOR_SEARCH_DEPTH: ${{ inputs.SCAN_DEPTH }}
       with:
         scan-mode: ${{ inputs.SCAN_TYPE }}
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Added environment variable to support scan depth
- Added input `SCAN_DEPTH` as optional input  `default: 0`

## Related Jira Tickets
- N/A

## UI changes
- N/A

## Dependencies
- N/A

## Anything Else?
- Found the environment variable documentation here https://synopsys.atlassian.net/wiki/spaces/INTDOCS/pages/631374044/Detect+Properties#Paths