### PR TITLE
Pick up Node version from .tool-versions

### DIFF
--- a/.github/workflows/synopsis-scan-sast.yml
+++ b/.github/workflows/synopsis-scan-sast.yml
@@ -40,11 +40,17 @@ jobs:
       with:
         java-version: '11'
         distribution: 'adopt'
-    
-    - name: Setup Node.JS 16
+
+    - name: Read .tool-versions
+      run: |
+        export NODE_VERSION=`cat .tool-versions | sed -n 's/nodejs //p'`
+        export NODE_VERSION="${NODE_VERSION:-16.15.0}"
+        echo NODE_VERSION=$NODE_VERSION >> $GITHUB_ENV
+
+    - name: Setup NodeJS
       uses: actions/setup-node@v3
       with:
-        node-version: '16.15.0'
+        node-version: ${{ env.NODE_VERSION }}
 
     - name: Execute the Synopys Detect script
       run: |


### PR DESCRIPTION
## Card

https://compono.atlassian.net/jira/software/projects/DEV/boards/12?selectedIssue=DEV-637

## Why?

Because not all of our projects are on Node 16. We should be providing a flexible way to have the environment matched to the app